### PR TITLE
Use SCRIPT_NAME instead of REQUEST_URI because we target a php script anyway but we don't want the query string

### DIFF
--- a/addons-wp-headless.php
+++ b/addons-wp-headless.php
@@ -11,7 +11,7 @@ function addons_disable_frontend()
     global $wp;
 
     $isAuth0Callback =
-        $_SERVER['REQUEST_URI'] === '/index.php' &&
+        $_SERVER['SCRIPT_NAME'] === '/index.php' &&
         !empty($_COOKIE['auth0_state']);
 
     // We allow CRON tasks, REST API requests, requests to the admin interface,


### PR DESCRIPTION
`REQUEST_URI` contains the query string (which I hadn't double checked???).
`SCRIPT_NAME` is fine as far as we don't have fancy url rewrite, so this works
and does what we want.