### PR TITLE
Run test suite on different WP versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,13 @@ job-references:
       sudo -E docker-php-ext-install mysqli
 
   php_job: &php_job
+    parameters:
+      wordpress-version:
+        type: string
     environment:
       - WP_TESTS_DIR: "/tmp/wordpress-tests-lib"
       - WP_CORE_DIR: "/tmp/wordpress/"
+      - WP_VERSION: << parameters.wordpress-version >>
     steps:
       - checkout
       - run: *install_dependencies
@@ -21,8 +25,8 @@ job-references:
           name: run tests
           command: |
             composer install
-            rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+            rm -rf "$WP_TESTS_DIR" "$WP_CORE_DIR"
+            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 "$WP_VERSION"
             ./vendor/bin/phpunit
             WP_MULTISITE=1 ./vendor/bin/phpunit
       - run:
@@ -41,4 +45,9 @@ jobs:
 workflows:
   default-workflow:
     jobs:
-      - tests
+      - tests:
+          matrix:
+            parameters:
+              wordpress-version:
+                - '5.6.2'
+                - 'latest'

--- a/README.md
+++ b/README.md
@@ -14,12 +14,20 @@ Important: you'll need [composer](https://getcomposer.org/) to install the proje
 
 ### Running the test suite
 
-This is a bit involved because there is no nice way to write "unit" tests with WordPress. We follow the recommended approach, which requires both a WordPress instance and MySQL database. The `bin/install-wp-tests.sh` script can be used to download and setup the WP instance as well as create the "test" database, which requires a local MySQL server.
-
-Assuming you have a MySQL server running locally (for instance a Docker container accessible at `127.0.0.1:55001`), run the following commands once:
+This is a bit involved because there is no nice way to write "unit" tests with WordPress. We follow the recommended approach, which requires both a WordPress instance and MySQL database. The `bin/install-wp-tests.sh` script can be used to download and setup the WP instance as well as create the "test" database, which requires a local MySQL server, e.g. with Docker:
 
 ```
-$ ./bin/install-wp-tests.sh test root '' '127.0.0.1:55001' 5.7.1 true
+$ docker run --name mysql_addons_wp_headless -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=addons_wp_headless -p 55001:3306 --rm mysql
+```
+
+Assuming you have a MySQL server running locally using the docker command above, run the following commands once:
+
+```
+# `5.7.1` is the WordPress version, use `latest` for the latest version or any
+# other version if you like.
+# `true` at the end of the command below skips the database creation since it is
+# created when the docker container starts
+$ ./bin/install-wp-tests.sh addons_wp_headless root pass '127.0.0.1:55001' 5.7.1 true
 $ composer install
 ```
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-wp-headless/issues/8

- 5.6.2 is the current version on WPEngine
- latest is... well latest

(the README update provides commands that are ready to use)