### PR TITLE
Update dependabot config (cooldown)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,12 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 99
+    cooldown:
+      default-days: 7
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 99
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This PR updates the dependabot config to match our recommended settings,
used in all the other repos.